### PR TITLE
add support for parameters references in path specs

### DIFF
--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -367,6 +367,9 @@ class SwaggerParser(object):
                 if 'parameters' in path_spec[action].keys():
                     for parameter in path_spec[action]['parameters']:
                         # Add to parameters
+                        if parameter.get('$ref'):
+                            # expand paremeter from $ref if not specified inline
+                            parameter = self.specification['parameters'].get( parameter.get('$ref').split('/')[-1] )
                         self.paths[path][action]['parameters'][parameter['name']] = parameter
 
                 # Get responses


### PR DESCRIPTION
currently the parser fails to add parameters if they are not defined in line but are defined in the parameter section of the swagger spec

look for an example here:

https://github.com/hjacobs/connexion-example/blob/master/swagger.yaml

This quick fix resolves the problem by expanding the parameter definition from the specification section using the '$ref' attribute.
Assuming the swagger spec is correct, there is no need for extra error checking.