### PR TITLE
added support for path-level parameters

### DIFF
--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -27,6 +27,8 @@ class SwaggerParser(object):
         paths: dict of path with their actions, parameters, and responses.
     """
 
+    _HTTP_VERBS = {'get', 'put', 'post', 'delete', 'options', 'head', 'patch'}
+
     def __init__(self, swagger_path=None, swagger_dict=None, use_example=True):
         """Run parsing from either a file or a dict.
 
@@ -355,7 +357,15 @@ class SwaggerParser(object):
         for path, path_spec in self.specification['paths'].items():
             self.paths[path] = {}
 
+            # Add path-level parameters
+            default_parameters = {}
+            if 'parameters' in path_spec:
+                self._add_parameters(default_parameters, path_spec['parameters'])
+
             for action in path_spec.keys():
+                if action not in self._HTTP_VERBS:
+                    continue
+
                 self.paths[path][action] = {}
 
                 # Add to operation list
@@ -363,17 +373,25 @@ class SwaggerParser(object):
                     self.operation[path_spec[action]['operationId']] = (path, action, path_spec[action]['tags'][0])
 
                 # Get parameters
-                self.paths[path][action]['parameters'] = {}
+                self.paths[path][action]['parameters'] = default_parameters.copy()
                 if 'parameters' in path_spec[action].keys():
-                    for parameter in path_spec[action]['parameters']:
-                        # Add to parameters
-                        if parameter.get('$ref'):
-                            # expand paremeter from $ref if not specified inline
-                            parameter = self.specification['parameters'].get(parameter.get('$ref').split('/')[-1])
-                        self.paths[path][action]['parameters'][parameter['name']] = parameter
+                    self._add_parameters(self.paths[path][action]['parameters'], path_spec[action]['parameters'])
 
                 # Get responses
                 self.paths[path][action]['responses'] = path_spec[action]['responses']
+
+    def _add_parameters(self, parameter_map, parameter_list):
+        """Populates the given parameter map with the list of parameters provided, resolving any reference objects encountered.
+
+        Args:
+            parameter_map: mapping from parameter names to parameter objects
+            parameter_list: list of either parameter objects or reference objects
+        """
+        for parameter in parameter_list:
+            if parameter.get('$ref'):
+                # expand parameter from $ref if not specified inline
+                parameter = self.specification['parameters'].get(parameter.get('$ref').split('/')[-1])
+            parameter_map[parameter['name']] = parameter
 
     @staticmethod
     def get_definition_name_from_ref(ref):

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -27,8 +27,8 @@ class SwaggerParser(object):
         paths: dict of path with their actions, parameters, and responses.
     """
 
-    _HTTP_VERBS = set('get', 'put', 'post', 'delete', 'options', 'head',
-                      'patch')
+    _HTTP_VERBS = set(['get', 'put', 'post', 'delete', 'options', 'head',
+                       'patch'])
 
     def __init__(self, swagger_path=None, swagger_dict=None, use_example=True):
         """Run parsing from either a file or a dict.

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -27,7 +27,8 @@ class SwaggerParser(object):
         paths: dict of path with their actions, parameters, and responses.
     """
 
-    _HTTP_VERBS = {'get', 'put', 'post', 'delete', 'options', 'head', 'patch'}
+    _HTTP_VERBS = set('get', 'put', 'post', 'delete', 'options', 'head',
+                      'patch')
 
     def __init__(self, swagger_path=None, swagger_dict=None, use_example=True):
         """Run parsing from either a file or a dict.

--- a/tests/swagger.yaml
+++ b/tests/swagger.yaml
@@ -150,8 +150,6 @@ paths:
       operationId: examples.api.api.getPetById
       produces:
         - application/json
-      parameters:
-        - $ref: '#/parameters/pet_id'
       responses:
         "404":
           description: Pet not found
@@ -177,11 +175,6 @@ paths:
       produces:
         - application/json
       parameters:
-        - in: path
-          name: petId
-          description: ID of pet that needs to be updated
-          required: true
-          type: string
         - in: query
           name: name
           description: Updated name of the pet
@@ -211,13 +204,6 @@ paths:
       operationId: examples.api.api.deletePet
       produces:
         - application/json
-      parameters:
-        - in: path
-          name: petId
-          description: Pet id to delete
-          required: true
-          type: integer
-          format: int64
       responses:
         "204":
           description: Deleted
@@ -227,6 +213,8 @@ paths:
         - petstore_auth:
           - write_pets
           - read_pets
+    parameters:
+      - $ref: '#/parameters/pet_id'
   /stores/order:
     post:
       tags:

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -106,19 +106,22 @@ def test_get_paths_data(swagger_parser, path_data_example):
     swagger_parser.get_paths_data()
     assert len(swagger_parser.paths) == 12
     assert swagger_parser.paths['/pets'] == path_data_example
+    pet_id_param = {
+        'name': 'petId',
+        'in': 'path',
+        'pattern': '^[a-zA-Z0-9-]+$',
+        'required': True,
+        'type': 'string',
+        'description': "Pet's Unique identifier",
+    }
     assert swagger_parser.paths['/pets/{petId}']['get'] == \
         {'responses': {'200': {'description': 'successful operation',
                                'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'}},
                        '404': {'description': 'Pet not found'},
                        '400': {'description': 'Invalid ID supplied'}},
-         'parameters': {'petId': {
-             'name': 'petId',
-             'in': 'path',
-             'pattern': '^[a-zA-Z0-9-]+$',
-             'required': True,
-             'type': 'string',
-             'description': "Pet's Unique identifier",
-         }}}
+         'parameters': {'petId': pet_id_param}}
+    assert swagger_parser.paths['/pets/{petId}']['post']['parameters']['petId'] == pet_id_param
+    assert swagger_parser.paths['/pets/{petId}']['delete']['parameters']['petId'] == pet_id_param
 
 
 def test_get_definition_name_from_ref(swagger_parser):


### PR DESCRIPTION
According to the spec Path Item Objects can include parameters:

http://swagger.io/specification/#pathItemObject

"A list of parameters that are applicable for all the operations described
under this path. These parameters can be overridden at the operation level, but
cannot be removed there."

This commit adds support for this scenario and modifies the existing tests to
provide coverage for it.