### PR TITLE
allow non ascii characters in swagger yaml specs

### DIFF
--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 
+import codecs
 import datetime
 import jinja2
 import json
 import re
 import six
 import yaml
-import codecs
 
 try:
     from StringIO import StringIO

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -6,6 +6,7 @@ import json
 import re
 import six
 import yaml
+import codecs
 
 try:
     from StringIO import StringIO
@@ -46,7 +47,7 @@ class SwaggerParser(object):
             if swagger_path is not None:
                 # Open yaml file
                 arguments = {}
-                with open(swagger_path, 'r') as swagger_yaml:
+                with codecs.open(swagger_path, 'r', 'utf-8') as swagger_yaml:
                     swagger_template = swagger_yaml.read()
                     swagger_string = jinja2.Template(swagger_template).render(**arguments)
                     self.specification = yaml.load(swagger_string)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def path_data_example():
     }, 'parameters': {'body': {
         'required': False,
         'in': 'body',
-        'description': 'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
+        'description': u'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
         'name': 'body',
         'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
     }}}, 'post': {'responses': {'201': {'description': 'Created',
@@ -53,7 +53,7 @@ def path_data_example():
                   'parameters': {'body': {
                       'required': False,
                       'in': 'body',
-                      'description': 'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
+                      'description': u'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
                       'name': 'body',
                       'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
                   }}}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def path_data_example():
     }, 'parameters': {'body': {
         'required': False,
         'in': 'body',
-        'description': u'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
+        'description': u'Pet object that needs to be added to the store',
         'name': 'body',
         'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
     }}}, 'post': {'responses': {'201': {'description': 'Created',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,7 +43,7 @@ def path_data_example():
     }, 'parameters': {'body': {
         'required': False,
         'in': 'body',
-        'description': 'µPet øbject that needs to be added to the store !',
+        'description': 'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
         'name': 'body',
         'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
     }}}, 'post': {'responses': {'201': {'description': 'Created',
@@ -53,7 +53,7 @@ def path_data_example():
                   'parameters': {'body': {
                       'required': False,
                       'in': 'body',
-                      'description': 'µPet øbject that needs to be added to the store !',
+                      'description': 'Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)',
                       'name': 'body',
                       'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
                   }}}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ def path_data_example():
     }, 'parameters': {'body': {
         'required': False,
         'in': 'body',
-        'description': 'Pet object that needs to be added to the store',
+        'description': 'µPet øbject that needs to be added to the store !',
         'name': 'body',
         'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
     }}}, 'post': {'responses': {'201': {'description': 'Created',
@@ -52,7 +52,7 @@ def path_data_example():
                   'parameters': {'body': {
                       'required': False,
                       'in': 'body',
-                      'description': 'Pet object that needs to be added to the store',
+                      'description': 'µPet øbject that needs to be added to the store !',
                       'name': 'body',
                       'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'},
                   }}}}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import pytest
 
 from swagger_parser import SwaggerParser

--- a/tests/swagger.yaml
+++ b/tests/swagger.yaml
@@ -133,7 +133,7 @@ paths:
           collectionFormat: multi
       responses:
         "200":
-          description: successful operation
+          description: successful µ-øperätioñ
           schema:
             type: array
             items:

--- a/tests/swagger.yaml
+++ b/tests/swagger.yaml
@@ -6,6 +6,9 @@ info:
     [Learn about Swagger](http://swagger.wordnik.com) or join the IRC channel `#swagger` on irc.freenode.net.
 
     For this sample, you can use the api key `special-key` to test the authorization filters
+    
+    NOTE: Swagger files mey contain non-acsii characters like µ, ü or ç and ñ, please save your file in UT8 to preserv them.
+    
   version: "1.0.0"
   title: Swagger Petstore
   termsOfService: http://helloreverb.com/terms/

--- a/tests/swagger.yaml
+++ b/tests/swagger.yaml
@@ -35,7 +35,7 @@ paths:
       parameters:
         - in: body
           name: body
-          description: Pet object that needs to be added to the store
+          description: Pet object that needs to be added to the store (it may be a µPig or a Smørebröd)
           required: false
           schema:
             $ref: "#/definitions/Pet"

--- a/tests/swagger.yaml
+++ b/tests/swagger.yaml
@@ -133,7 +133,7 @@ paths:
           collectionFormat: multi
       responses:
         "200":
-          description: successful µ-øperätioñ
+          description: successful operation
           schema:
             type: array
             items:
@@ -159,7 +159,7 @@ paths:
         "404":
           description: Pet not found
         "200":
-          description: successful operation
+          description: successful µ-øperätioñ
           schema:
             $ref: "#/definitions/Pet"
         "400":

--- a/tests/swagger.yaml
+++ b/tests/swagger.yaml
@@ -7,7 +7,7 @@ info:
 
     For this sample, you can use the api key `special-key` to test the authorization filters
     
-    NOTE: Swagger files mey contain non-acsii characters like µ, ü or ç and ñ, please save your file in UT8 to preserv them.
+    Swagger files may contain non-ascii characters like µ, ü or ç and ñ, please save your file in UTF-8 to preserve them.
     
   version: "1.0.0"
   title: Swagger Petstore

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -107,7 +107,7 @@ def test_get_paths_data(swagger_parser, path_data_example):
     assert len(swagger_parser.paths) == 12
     assert swagger_parser.paths['/pets'] == path_data_example
     assert swagger_parser.paths['/pets/{petId}']['get'] == \
-        {'responses': {'200': {'description': 'successful operation',
+        {'responses': {'200': {'description': 'successful µ-øperätioñ',
                                'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'}},
                        '404': {'description': 'Pet not found'},
                        '400': {'description': 'Invalid ID supplied'}},

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -107,7 +107,7 @@ def test_get_paths_data(swagger_parser, path_data_example):
     assert len(swagger_parser.paths) == 12
     assert swagger_parser.paths['/pets'] == path_data_example
     assert swagger_parser.paths['/pets/{petId}']['get'] == \
-        {'responses': {'200': {'description': 'successful µ-øperätioñ',
+        {'responses': {'200': {'description': u'successful µ-øperätioñ',
                                'schema': {'x-scope': [''], '$ref': '#/definitions/Pet'}},
                        '404': {'description': 'Pet not found'},
                        '400': {'description': 'Invalid ID supplied'}},


### PR DESCRIPTION
the current version cannot handle non-ascii characters readling the yaml file.

assuming the file is encoded in UTF8 this will fix that.