### PR TITLE
Generate operations without operationId

### DIFF
--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -77,7 +77,7 @@ class SwaggerParser(object):
 
     def build_definitions_example(self):
         """Parse all definitions in the swagger specification."""
-        for def_name, def_spec in self.specification['definitions'].items():
+        for def_name, def_spec in self.specification.get('definitions', {}).items():
             self.build_one_definition_example(def_name)
 
     def build_one_definition_example(self, def_name):

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -397,7 +397,7 @@ class SwaggerParser(object):
                     #       URL paths and actions should encode to UTF-8 safely.
                     import hashlib
                     h = hashlib.sha256()
-                    h.update("%s|%s".encode('utf-8') % (action, path))
+                    h.update(("%s|%s" % (action, path)).encode('utf-8'))
                     self.generated_operation[h.hexdigest()] = (path, action, tag)
 
                 # Get parameters

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -392,9 +392,12 @@ class SwaggerParser(object):
                 if 'operationId' in path_spec[action].keys():
                     self.operation[path_spec[action]['operationId']] = (path, action, tag)
                 else:
+                    # Note: the encoding chosen below isn't very important in this
+                    #       case; what matters is a byte string that is unique.
+                    #       URL paths and actions should encode to UTF-8 safely.
                     import hashlib
                     h = hashlib.sha256()
-                    h.update("%s|%s" % (action, path))
+                    h.update("%s|%s".encode('utf-8') % (action, path))
                     self.generated_operation[h.hexdigest()] = (path, action, tag)
 
                 # Get parameters

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -73,6 +73,7 @@ class SwaggerParser(object):
         self.build_definitions_example()
         self.paths = {}
         self.operation = {}
+        self.generated_operation = {}
         self.get_paths_data()
 
     def build_definitions_example(self):
@@ -387,9 +388,14 @@ class SwaggerParser(object):
                 self.paths[path][action] = {}
 
                 # Add to operation list
+                tag = path_spec[action]['tags'][0] if 'tags' in path_spec[action].keys() and path_spec[action]['tags'] else None
                 if 'operationId' in path_spec[action].keys():
-                    tag = path_spec[action]['tags'][0] if 'tags' in path_spec[action].keys() and path_spec[action]['tags'] else None
                     self.operation[path_spec[action]['operationId']] = (path, action, tag)
+                else:
+                    import hashlib
+                    h = hashlib.sha256()
+                    h.update("%s|%s" % (action, path))
+                    self.generated_operation[h.hexdigest()] = (path, action, tag)
 
                 # Get parameters
                 self.paths[path][action]['parameters'] = default_parameters.copy()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@ from swagger_parser import SwaggerParser
 def swagger_parser():
     return SwaggerParser('tests/swagger.yaml')
 
+@pytest.fixture
+def inline_parser():
+    return SwaggerParser('tests/inline.yaml')
+
 
 @pytest.fixture
 def pet_definition_example():
@@ -29,6 +33,13 @@ def pet_definition_example():
             'string2'
         ],
         'id': 42
+    }
+
+
+@pytest.fixture
+def inline_example():
+    return {
+        '3bd818fb7d55daf2fb8bf3354c061f9ba7f8cece39b30bdcb7e05551053ec2e8': ('/test', 'post', None)
     }
 
 

--- a/tests/inline.yaml
+++ b/tests/inline.yaml
@@ -1,0 +1,43 @@
+swagger: '2.0'
+info:
+  version: '2016-01-19T11:24:50Z'
+  title: authentication tests
+schemes:
+- http
+paths:
+  /test:
+    post:
+      summary: Post something complex
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - name: complex
+        in: body
+        required: true
+        schema:
+          type: object
+          properties:
+            foo:
+              type: object
+              properties:
+                bar:
+                  type: string
+                baz:
+                  type: integer
+              required:
+              - bar
+              - baz
+          required:
+          - foo
+          example:
+            foo:
+              bar: 'hello'
+              baz: 123
+      responses:
+        '201':
+          description: Created
+        default:
+          description: Not created
+

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -2,6 +2,10 @@
 # -*- coding: utf-8 -*-
 
 
+def test_inline_examples(inline_parser, inline_example):
+    assert inline_parser.generated_operation == inline_example
+
+
 def test_build_definitions_example(swagger_parser, pet_definition_example):
     # Test definitions_example
     swagger_parser.build_definitions_example()


### PR DESCRIPTION
Operations exist, whether or not an operationId is specified. In order to avoid clobbering operations with an operationId, just put them in a different dict.

Note: #20 is included in this PR.