### PR TITLE
Example from properties

### DIFF
--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -77,7 +77,7 @@ class SwaggerParser(object):
 
     def build_definitions_example(self):
         """Parse all definitions in the swagger specification."""
-        for def_name, def_spec in self.specification['definitions'].items():
+        for def_name, def_spec in self.specification.get('definitions', {}).items():
             self.build_one_definition_example(def_name)
 
     def build_one_definition_example(self, def_name):

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -397,7 +397,7 @@ class SwaggerParser(object):
                     #       URL paths and actions should encode to UTF-8 safely.
                     import hashlib
                     h = hashlib.sha256()
-                    h.update("%s|%s".encode('utf-8') % (action, path))
+                    h.update(("%s|%s" % (action, path)).encode('utf-8'))
                     self.generated_operation[h.hexdigest()] = (path, action, tag)
 
                 # Get parameters

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -392,9 +392,12 @@ class SwaggerParser(object):
                 if 'operationId' in path_spec[action].keys():
                     self.operation[path_spec[action]['operationId']] = (path, action, tag)
                 else:
+                    # Note: the encoding chosen below isn't very important in this
+                    #       case; what matters is a byte string that is unique.
+                    #       URL paths and actions should encode to UTF-8 safely.
                     import hashlib
                     h = hashlib.sha256()
-                    h.update("%s|%s" % (action, path))
+                    h.update("%s|%s".encode('utf-8') % (action, path))
                     self.generated_operation[h.hexdigest()] = (path, action, tag)
 
                 # Get parameters

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -178,7 +178,13 @@ class SwaggerParser(object):
                 return self._get_example_from_basic_type(prop_spec['type'])[0]
 
     def _get_example_from_properties(self, spec):
-        """
+        """Get example from the properties of an object defined inline.
+
+        Args:
+            prop_spec: property specification you want an example of.
+
+        Returns:
+            An example.
         """
         example = {}
         required = spec.get('required', spec['properties'].keys())

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -73,6 +73,7 @@ class SwaggerParser(object):
         self.build_definitions_example()
         self.paths = {}
         self.operation = {}
+        self.generated_operation = {}
         self.get_paths_data()
 
     def build_definitions_example(self):
@@ -387,9 +388,14 @@ class SwaggerParser(object):
                 self.paths[path][action] = {}
 
                 # Add to operation list
+                tag = path_spec[action]['tags'][0] if 'tags' in path_spec[action].keys() and path_spec[action]['tags'] else None
                 if 'operationId' in path_spec[action].keys():
-                    tag = path_spec[action]['tags'][0] if 'tags' in path_spec[action].keys() and path_spec[action]['tags'] else None
                     self.operation[path_spec[action]['operationId']] = (path, action, tag)
+                else:
+                    import hashlib
+                    h = hashlib.sha256()
+                    h.update("%s|%s" % (action, path))
+                    self.generated_operation[h.hexdigest()] = (path, action, tag)
 
                 # Get parameters
                 self.paths[path][action]['parameters'] = default_parameters.copy()

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -163,6 +163,8 @@ class SwaggerParser(object):
             return self._example_from_definition(prop_spec)
         elif 'type' not in prop_spec:  # Complex type
             return self._example_from_complex_def(prop_spec)
+        elif prop_spec['type'] == 'object': # From properties, without references
+          return [self._get_example_from_properties(prop_spec)]
         elif prop_spec['type'] == 'array':  # Array
             return self._example_from_array_spec(prop_spec)
         elif prop_spec['type'] == 'file':  # File
@@ -174,6 +176,26 @@ class SwaggerParser(object):
                 return self._get_example_from_basic_type(prop_spec['type'][0])[0]
             else:
                 return self._get_example_from_basic_type(prop_spec['type'])[0]
+
+    def _get_example_from_properties(self, spec):
+        """
+        """
+        example = {}
+        required = spec.get('required', spec['properties'].keys())
+        for inner_name, inner_spec in spec['properties'].items():
+            if inner_name not in required:
+                continue
+
+            partial = self.get_example_from_prop_spec(inner_spec)
+            # While get_example_from_prop_spec is supposed to return a list,
+            # we don't actually want that when recursing to build from
+            # properties
+            if isinstance(partial, list):
+                partial = partial[0]
+
+            example[inner_name] = partial
+        return example
+
 
     @staticmethod
     def _get_example_from_basic_type(type):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,10 @@ from swagger_parser import SwaggerParser
 def swagger_parser():
     return SwaggerParser('tests/swagger.yaml')
 
+@pytest.fixture
+def inline_parser():
+    return SwaggerParser('tests/inline.yaml')
+
 
 @pytest.fixture
 def pet_definition_example():
@@ -29,6 +33,13 @@ def pet_definition_example():
             'string2'
         ],
         'id': 42
+    }
+
+
+@pytest.fixture
+def inline_example():
+    return {
+        '3bd818fb7d55daf2fb8bf3354c061f9ba7f8cece39b30bdcb7e05551053ec2e8': ('/test', 'post', None)
     }
 
 

--- a/tests/inline.yaml
+++ b/tests/inline.yaml
@@ -1,0 +1,43 @@
+swagger: '2.0'
+info:
+  version: '2016-01-19T11:24:50Z'
+  title: authentication tests
+schemes:
+- http
+paths:
+  /test:
+    post:
+      summary: Post something complex
+      produces:
+      - application/json
+      consumes:
+      - application/json
+      parameters:
+      - name: complex
+        in: body
+        required: true
+        schema:
+          type: object
+          properties:
+            foo:
+              type: object
+              properties:
+                bar:
+                  type: string
+                baz:
+                  type: integer
+              required:
+              - bar
+              - baz
+          required:
+          - foo
+          example:
+            foo:
+              bar: 'hello'
+              baz: 123
+      responses:
+        '201':
+          description: Created
+        default:
+          description: Not created
+

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-
 def test_build_definitions_example(swagger_parser, pet_definition_example):
     # Test definitions_example
     swagger_parser.build_definitions_example()
@@ -77,6 +76,24 @@ def test_get_example_from_prop_spec(swagger_parser):
     prop_spec['items']['$ref'] = '#/definitions/Tag'
     assert swagger_parser.get_example_from_prop_spec(prop_spec) == [{'id': 42, 'name': 'string'}]
 
+    # Inline complex
+    prop_spec = {
+      'type': 'object',
+      'properties': {
+        'error': {
+          'type': 'object',
+          'properties': {
+            'code': { 'type': 'string' },
+            'title': { 'type': 'string' },
+            'detail': { 'type': 'string' },
+          },
+          'required': ['code', 'title', 'detail'],
+        },
+      },
+      'required': ['error'],
+    }
+    example = swagger_parser.get_example_from_prop_spec(prop_spec)
+    assert example == [{'error': {'code': 'string', 'detail': 'string', 'title': 'string'}}]
 
 def test_get_dict_definition(swagger_parser, pet_definition_example):
     assert swagger_parser.get_dict_definition(pet_definition_example) == 'Pet'

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+
+def test_inline_examples(inline_parser, inline_example):
+    assert inline_parser.generated_operation == inline_example
+
+
 def test_build_definitions_example(swagger_parser, pet_definition_example):
     # Test definitions_example
     swagger_parser.build_definitions_example()


### PR DESCRIPTION
There is no requirement in swagger for using definitions. Instead, it's perfectly possible to write response properties directly into the response objects.

Therefore swagger-parser should be able to generate examples from such objects. That's what this changeset is about.

Note: this PR includes #20 and #21 