### PR TITLE
Use isinstance for simple type checking

### DIFF
--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -279,9 +279,9 @@ class SwaggerParser(object):
         assert isinstance(example, dict)
 
         def _has_simple_type(value):
-            accepted = [str, int, float, bool]
-            return any(isinstance(value, x) for x in accepted)
-
+            accepted = (str, int, float, bool)
+            return isinstance(value, accepted)
+        
         definition = {
             'type': 'object',
             'properties': {},

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -281,7 +281,7 @@ class SwaggerParser(object):
         def _has_simple_type(value):
             accepted = (str, int, float, bool)
             return isinstance(value, accepted)
-        
+
         definition = {
             'type': 'object',
             'properties': {},


### PR DESCRIPTION
As per `%timeit` in IPython, new implementation takes half time as compared to old one. I used following code to test:

```python
values = ['abcd', 234, False, True, None, {}, [], object(), 2.7]
_types = [_has_simple_type_1(x) for x in values]
```