### PR TITLE
Add all of support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ matrix:
   include:
     - python: 2.7
       env: TOX_ENV=py27
-    - python: 3.3
-      env: TOX_ENV=py33
     - python: 3.4
       env: TOX_ENV=py34
     - python: 3.5

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from pip.req import parse_requirements
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
+
+
+def parse_requirements(filename):
+    """ load requirements from a pip requirements file """
+    lineiter = (line.strip() for line in open(filename))
+    return [line for line in lineiter if line and not line.startswith("#")]
 
 
 with open('README.rst') as readme_file:
@@ -14,8 +19,8 @@ with open('README.rst') as readme_file:
 with open('HISTORY.rst') as history_file:
     history = history_file.read()
 
-requirements = [str(i.req) for i in parse_requirements('requirements.txt', session=False)]
-test_requirements = [str(i.req) for i in parse_requirements('requirements_dev.txt', session=False)]
+requirements = parse_requirements('requirements.txt')
+test_requirements = parse_requirements('requirements_dev.txt')
 
 setup(
     name='swagger_parser',

--- a/swagger_parser/swagger_parser.py
+++ b/swagger_parser/swagger_parser.py
@@ -155,7 +155,7 @@ class SwaggerParser(object):
         else:
             return False
 
-    def get_example_from_prop_spec(self, prop_spec, from_allof = False):
+    def get_example_from_prop_spec(self, prop_spec, from_allof=False):
         """Return an example value from a property specification.
 
         Args:

--- a/tests/allof.yaml
+++ b/tests/allof.yaml
@@ -26,6 +26,9 @@ definitions:
         another_property:
             description: another property
             type: string
+        some_integer:
+            description: an integer
+            type: integer
   someObject:
     description: some object
     allOf:

--- a/tests/allof.yaml
+++ b/tests/allof.yaml
@@ -20,15 +20,25 @@ definitions:
         a_property:
            description: a property
            type: string
+  anotherBaseObject:
+    description: another base object
+    properties:
+        another_property:
+            description: another property
+            type: string
   someObject:
     description: some object
     allOf:
       - $ref: '#/definitions/baseObject'
-    properties:
-      some_property:
-        description: some property
-        type: string
-    required:
-      - a_property
-    type: object
-    
+      - type: object
+        properties:
+          some_property:
+            description: some property
+            type: string
+        required:
+          - some_property
+  anotherObject:
+    description: another object
+    allOf:
+      - $ref: '#/definitions/baseObject'
+      - $ref: '#/definitions/anotherBaseObject'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,18 +16,25 @@ def swagger_allof_parser():
 
 
 @pytest.fixture
+def swagger_test2_parser():
+    return SwaggerParser('tests/test.yaml')
+
+
+@pytest.fixture
 def inline_parser():
     return SwaggerParser('tests/inline.yaml')
 
 
 @pytest.fixture(scope="module",
-                params=['tests/no_properties.yaml',
-                        'tests/object_no_schema.yaml',
-                        'tests/allof.yaml',
-                        'tests/array_ref_simple.yaml',
-                        'tests/null_type.yaml',
-                        'tests/array_items_list.yaml',
-                        'tests/type_list.yaml',
+                params=[  # 'tests/no_properties.yaml',
+                          # 'tests/object_no_schema.yaml',
+                          # 'tests/allof.yaml',
+                          # 'tests/array_ref_simple.yaml',
+                          # 'tests/null_type.yaml',
+                          # 'tests/array_items_list.yaml',
+                          # 'tests/type_list.yaml',
+                        'tests/test.yaml',
+                          # 'tests/test2.yaml',
                         ])
 def swagger_file_parser(request):
     return SwaggerParser(request.param)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,11 @@ def swagger_parser():
 
 
 @pytest.fixture
+def swagger_allof_parser():
+    return SwaggerParser('tests/allof.yaml')
+
+
+@pytest.fixture
 def inline_parser():
     return SwaggerParser('tests/inline.yaml')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,15 +26,13 @@ def inline_parser():
 
 
 @pytest.fixture(scope="module",
-                params=[  # 'tests/no_properties.yaml',
-                          # 'tests/object_no_schema.yaml',
-                          # 'tests/allof.yaml',
-                          # 'tests/array_ref_simple.yaml',
-                          # 'tests/null_type.yaml',
-                          # 'tests/array_items_list.yaml',
-                          # 'tests/type_list.yaml',
-                        'tests/test.yaml',
-                          # 'tests/test2.yaml',
+                params=['tests/no_properties.yaml',
+                        'tests/object_no_schema.yaml',
+                        'tests/allof.yaml',
+                        'tests/array_ref_simple.yaml',
+                        'tests/null_type.yaml',
+                        'tests/array_items_list.yaml',
+                        'tests/type_list.yaml',
                         ])
 def swagger_file_parser(request):
     return SwaggerParser(request.param)

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -390,6 +390,7 @@ def test_allof_handling(swagger_allof_parser):
     another_example = swagger_allof_parser.definitions_example['anotherObject']
     assert 'a_property' in another_example
     assert 'another_property' in another_example
+    assert 'some_integer' in another_example
 
 
 @pytest.mark.skip

--- a/tests/test_swagger_parser.py
+++ b/tests/test_swagger_parser.py
@@ -382,6 +382,16 @@ def test_referenced_additional_property_handling(swagger_parser):
     assert not swagger_parser.validate_additional_properties(additional_properties, bad_response)
 
 
+def test_allof_handling(swagger_allof_parser):
+    example = swagger_allof_parser.definitions_example['someObject']
+    assert 'a_property' in example
+    assert 'some_property' in example
+
+    another_example = swagger_allof_parser.definitions_example['anotherObject']
+    assert 'a_property' in another_example
+    assert 'another_property' in another_example
+
+
 @pytest.mark.skip
 def test_list_additional_property_handling(swagger_parser):
     # TODO list handling in additionalProperties is not implemented yet

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, py36, pypy, flake8
+envlist = py27, py34, py35, py36, pypy, flake8
 
 [testenv]
 setenv =


### PR DESCRIPTION
I've added support for the `allOf` property. The parser checks for an `allOf` section and, if it finds one, iterates through each of the items in the list feeding them back through the `get_example_from_prop_spec` method. In this case a `from_allof` flag is set so that the resultant example is returned as a dictionary that can be added to the other components of the example.
I've also updated the tests to check that the different examples of `allOf` sections are parsed correctly.